### PR TITLE
doc: basics: fix various typos

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -13,7 +13,7 @@ You can easily use adb to get a list of the currently connected devices.::
     >> adb.get_devices()
     {0: '12601aabbccdd124', 1: 'abc1551124de1241'}
 
-Notice how ``get_devices()`` returns a dictionary with an index and the device identifer.
+Notice how ``get_devices()`` returns a dictionary with an index and the device identifier.
 
 Setting a target device
 -----------------------
@@ -29,7 +29,7 @@ In order to interact with a device you need to tell pyand which device you want 
 
 Getting device state
 --------------------
-Note how that dictionary returned by ``get_devices()`` does not indicate the state of the device(s). You can use ``get_state()`` for that. Remeber ot set a device target first.::
+Note how that dictionary returned by ``get_devices()`` does not indicate the state of the device(s). You can use ``get_state()`` for that. Remember to set a device target first.::
 
     >> adb.get_state()
     unauthorized


### PR DESCRIPTION
s/identifer/identifier
s/Remeber/Remember/
s/ot/to

Found with flyspell

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>